### PR TITLE
ASDPLNG-38 Add OS Specific inbuilt_chains

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -11,6 +11,8 @@ profile_firewall::purge_all: true
 
 profile_firewall::ignores: {}
 
+# Leave some generic inbuilt_chains, but each OS should have their own
+# copy of inbuilt_chains in hiera under data/os/..
 profile_firewall::inbuilt_chains:
   FORWARD:filter:IPv4:
   FORWARD:filter:IPv6:

--- a/data/os/RedHat/7.yaml
+++ b/data/os/RedHat/7.yaml
@@ -1,0 +1,48 @@
+---
+profile_firewall::inbuilt_chains:
+  FORWARD:filter:IPv4:
+  FORWARD:filter:IPv6:
+  FORWARD:filter:ethernet:
+  INPUT:filter:IPv4:
+  INPUT:filter:IPv6:
+  INPUT:filter:ethernet:
+  OUTPUT:filter:IPv4:
+  OUTPUT:filter:IPv6:
+  OUTPUT:filter:ethernet:
+
+  INPUT:nat:IPv4:
+  INPUT:nat:IPv6:
+  PREROUTING:nat:IPv4:
+  PREROUTING:nat:IPv6:
+  PREROUTING:nat:ethernet:
+  POSTROUTING:nat:IPv4:
+  POSTROUTING:nat:IPv6:
+  POSTROUTING:nat:ethernet:
+  OUTPUT:nat:IPv4:
+  OUTPUT:nat:IPv6:
+  OUTPUT:nat:ethernet:
+
+  FORWARD:mangle:IPv4:
+  FORWARD:mangle:IPv6:
+  INPUT:mangle:IPv4:
+  INPUT:mangle:IPv6:
+  OUTPUT:mangle:IPv4:
+  OUTPUT:mangle:IPv6:
+  POSTROUTING:mangle:IPv4:
+  POSTROUTING:mangle:IPv6:
+  PREROUTING:mangle:IPv4:
+  PREROUTING:mangle:IPv6:
+
+  OUTPUT:raw:IPv4:
+  OUTPUT:raw:IPv6:
+  PREROUTING:raw:IPv4:
+  PREROUTING:raw:IPv6:
+
+  INPUT:security:IPv4:
+  FORWARD:security:IPv4:
+  OUTPUT:security:IPv4:
+  INPUT:security:IPv6:
+  FORWARD:security:IPv6:
+  OUTPUT:security:IPv6:
+
+  BROUTING:broute:ethernet:

--- a/data/os/RedHat/8.yaml
+++ b/data/os/RedHat/8.yaml
@@ -1,0 +1,46 @@
+---
+profile_firewall::inbuilt_chains:
+  FORWARD:filter:IPv4:
+  FORWARD:filter:IPv6:
+  FORWARD:filter:ethernet:
+  INPUT:filter:IPv4:
+  INPUT:filter:IPv6:
+  INPUT:filter:ethernet:
+  OUTPUT:filter:IPv4:
+  OUTPUT:filter:IPv6:
+  OUTPUT:filter:ethernet:
+
+  INPUT:nat:IPv4:
+  INPUT:nat:IPv6:
+  PREROUTING:nat:IPv4:
+  PREROUTING:nat:IPv6:
+  PREROUTING:nat:ethernet:
+  POSTROUTING:nat:IPv4:
+  POSTROUTING:nat:IPv6:
+  POSTROUTING:nat:ethernet:
+  OUTPUT:nat:IPv4:
+  OUTPUT:nat:IPv6:
+  OUTPUT:nat:ethernet:
+
+  FORWARD:mangle:IPv4:
+  FORWARD:mangle:IPv6:
+  INPUT:mangle:IPv4:
+  INPUT:mangle:IPv6:
+  OUTPUT:mangle:IPv4:
+  OUTPUT:mangle:IPv6:
+  POSTROUTING:mangle:IPv4:
+  POSTROUTING:mangle:IPv6:
+  PREROUTING:mangle:IPv4:
+  PREROUTING:mangle:IPv6:
+
+  OUTPUT:raw:IPv4:
+  OUTPUT:raw:IPv6:
+  PREROUTING:raw:IPv4:
+  PREROUTING:raw:IPv6:
+
+  INPUT:security:IPv4:
+  FORWARD:security:IPv4:
+  OUTPUT:security:IPv4:
+  INPUT:security:IPv6:
+  FORWARD:security:IPv6:
+  OUTPUT:security:IPv6:


### PR DESCRIPTION
RH7 has extra in-built chains that RH8 does not have (BROUTING).
The default list of inbuilt_chains from common.yaml only had
the default RH8 chains, so on a RH7 system warnings would be
generated when puppet tried to delete the built-in chains.

Setup a data/os/RedHat/7.yaml and data/os/RedHat/8.yaml that
will have their own OS specific overrides for inbuilt_chains

common.yaml still includes a basic set of inbuilt_chains, so
new Linux families and RedHat versions will at least have some
basic list, but to avoid warnings a family/version copy should
be created.