### PR TITLE
pdk 2.6.1 fixes pdk-validate action

### DIFF
--- a/.github/workflows/pdk-validate.yml
+++ b/.github/workflows/pdk-validate.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Clone repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Run pdk validate"
         uses: "puppets-epic-show-theatre/action-pdk-validate@v1"
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -13,22 +13,31 @@ def location_for(place_or_version, fake_version = nil)
   end
 end
 
-ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
-minor_version = ruby_version_segments[0..1].join('.')
-
 group :development do
-  gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 2.8.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "voxpupuli-puppet-lint-plugins", '>= 3.0',                 require: false
+  gem "json", '= 2.1.0',                               require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.3.0',                               require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.5.1',                               require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.1',                               require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.3',                               require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "voxpupuli-puppet-lint-plugins", '~> 3.1',       require: false
+  gem "facterdb", '~> 1.18',                           require: false
+  gem "metadata-json-lint", '>= 2.0.2', '< 4.0.0',     require: false
+  gem "puppetlabs_spec_helper", '>= 3.0.0', '< 5.0.0', require: false
+  gem "rspec-puppet-facts", '~> 2.0',                  require: false
+  gem "codecov", '~> 0.2',                             require: false
+  gem "dependency_checker", '~> 0.2',                  require: false
+  gem "parallel_tests", '~> 3.4',                      require: false
+  gem "pry", '~> 0.10',                                require: false
+  gem "simplecov-console", '~> 0.5',                   require: false
+  gem "puppet-debugger", '~> 1.0',                     require: false
+  gem "rubocop", '= 1.6.1',                            require: false
+  gem "rubocop-performance", '= 1.9.1',                require: false
+  gem "rubocop-rspec", '= 2.0.1',                      require: false
+  gem "rb-readline", '= 0.5.5',                        require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby]
+  gem "serverspec", '~> 2.41',    require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/lib/facter/custom_firewallchains.rb
+++ b/lib/facter/custom_firewallchains.rb
@@ -3,10 +3,10 @@
 Facter.add(:custom_firewallchains) do
   # https://puppet.com/docs/puppet/latest/fact_overview.html
   setcode do
-    data = Hash.new
-    for table in [ 'nat', 'filter' ] do
-      lines = Facter::Core::Execution.execute( "/usr/sbin/iptables -t #{table} -S" )
-      chain_names = lines.scan(/^-N (.+)$/).flatten
+    data = {}
+    [ 'nat', 'filter' ].each do |table|
+      lines = Facter::Core::Execution.execute("/usr/sbin/iptables -t #{table} -S")
+      chain_names = lines.scan('/^-N (.+)$/').flatten
       chain_names.each do |name|
         data[name] = { 'chain' => name, 'table' => table, 'protocol' => 'IPv4' }
       end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,7 +54,6 @@ class profile_firewall (
   Hash    $pre,
   Hash    $rules,
 ) {
-
   class { 'firewall':
     ebtables_manage => true,
   }
@@ -66,13 +65,12 @@ class profile_firewall (
   if empty($ignores) and empty($ignore_chain_prefixes) {
     # Not using ignores, ok to purge all
     resources { 'firewall':
-      purge =>  true,
+      purge => true,
     }
     resources { 'firewallchain':
-      purge =>  true,
+      purge => true,
     }
   } else {
-
     # Ignore any non-standard chains matching specified prefixes
     $ignore_chain_prefixes.each | $pfx | {
       $facts['custom_firewallchains'].each | $chain, $data | {
@@ -91,7 +89,6 @@ class profile_firewall (
       purge  => true,
     }
     $inbuilt_chains.each | $chain_name, $inbuilt_params | {
-
       # Combine params from hiera with chain defaults
       $custom_params = $inbuilt_params ? {
         undef   => $default_params,
@@ -110,9 +107,8 @@ class profile_firewall (
       # }
 
       firewallchain { $chain_name :
-          * => $chain_params,
+        * => $chain_params,
       }
-
     }
   }
 
@@ -121,5 +117,4 @@ class profile_firewall (
     create_resources( firewall, $rules )
   }
   create_resources( firewall, $post )
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
       "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],
-  "pdk-version": "2.5.0",
-  "template-url": "pdk-default#2.5.0",
-  "template-ref": "tags/2.5.0-0-g369d483"
+  "pdk-version": "2.6.1",
+  "template-url": "pdk-default#2.7.1",
+  "template-ref": "tags/2.7.1-0-g9a16c87"
 }


### PR DESCRIPTION
Changes:

- fixes the "pdk-validate" action ( as per https://github.com/puppetlabs/pdk-docker/issues/43 )

- bump actions/checkout@v3 (as per https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ )

- fixes for pdk validate